### PR TITLE
Only terminate if we're not in Playnite Fullscreen.

### DIFF
--- a/PlayNiteWatcherExt/PlayniteWatcherExtension.psm1
+++ b/PlayNiteWatcherExt/PlayniteWatcherExtension.psm1
@@ -53,7 +53,13 @@ function OnGameStarted() {
 
 function OnGameStopped() {
     param($evnArgs)
-    Send-PipeMessage -pipeName "PlayniteWatcher" -message "Terminate"
+
+    $mode = $PlayniteApi.ApplicationInfo.Mode
+    $isFullscreen = $mode -eq [Playnite.SDK.ApplicationMode]::Fullscreen
+
+    if (!$isFullscreen) {
+        Send-PipeMessage -pipeName "PlayniteWatcher" -message "Terminate"
+    }
 }
 
 function OnGameInstalled() {


### PR DESCRIPTION
This fixes stream getting terminated when a game is launched, then quit, when streaming "PlayNite Fullscreen App" shortcut.